### PR TITLE
Fix habit calendar completion check

### DIFF
--- a/app/src/main/java/com/cmp/microhabit/ui/component/calendar/HabitCalendarView.kt
+++ b/app/src/main/java/com/cmp/microhabit/ui/component/calendar/HabitCalendarView.kt
@@ -120,10 +120,10 @@ fun GetDayText(day: String) {
 
 @Composable
 fun GetCircularBg(date: String, dateLogs: Map<String, Boolean>) {
-    val isCompleted = if (dateLogs.contains(date) == true) {
-        dateLogs[date]
+    val isCompleted: Boolean = if (dateLogs.containsKey(date)) {
+        dateLogs[date] ?: false
     } else {
-        HabitLog()
+        false
     }
 
     val infiniteTransition = rememberInfiniteTransition()


### PR DESCRIPTION
## Summary
- fix completion lookup for HabitCalendarView

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*
- `./gradlew :app:compileDebugKotlin --no-daemon` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683d3ed61520832f9f25e0c53a405299